### PR TITLE
Fix weapon switching

### DIFF
--- a/scenes/objects/player/weapons.gd
+++ b/scenes/objects/player/weapons.gd
@@ -10,18 +10,18 @@ var weapon_index := 0
 func _ready() -> void:
 	weapon = weapons[weapon_index] # Weapon must never be nil
 
-func _unhandled_input(event: InputEvent) -> void:
+func _process(delta: float) -> void:
+	if weapons[old_weapon_index].lowering: return
+	
 	if Input.is_action_just_pressed("switch_previous"):
 		old_weapon_index = weapon_index
 		weapon_index = wrap(weapon_index - 1, 0, weapons.size())
 		initiate_change_weapon(weapon_index, old_weapon_index)
-		old_weapon_index = weapon_index
 
 	if Input.is_action_just_pressed("switch_next"):
 		old_weapon_index = weapon_index
 		weapon_index = wrap(weapon_index + 1, 0, weapons.size())
 		initiate_change_weapon(weapon_index, old_weapon_index)
-		old_weapon_index = weapon_index
 
 func initiate_change_weapon(index, old_index) -> void:
 	weapons[old_index].deselect_weapon()

--- a/scenes/objects/player/weapons/weapon.gd
+++ b/scenes/objects/player/weapons/weapon.gd
@@ -4,10 +4,12 @@ class_name Weapon
 
 # Signals
 signal lowered
+var lowering := false
 signal raised
+var raising := false
 
 # Variables
-var fireable = true
+var fireable := true
 
 # References
 @onready var anim = $Model/AnimationPlayer
@@ -17,8 +19,9 @@ var fireable = true
 func select_weapon() -> void:
 	fireable = false
 	anim.play_backwards("Lower")
+	raising = true
 	await anim.animation_finished
-	print("switched")
+	raising = false
 	emit_signal("raised")
 	anim.play("Idle")
 	fireable = true
@@ -26,7 +29,9 @@ func select_weapon() -> void:
 func deselect_weapon() -> void:
 	fireable = false
 	anim.play("Lower")
+	lowering = true
 	await anim.animation_finished
+	lowering = false
 	emit_signal("lowered")
 
 ## Fires a hitscan attack where [code]raycast[/code] is pointing.


### PR DESCRIPTION
This PR fixes a bug with weapon switching, where attempting to switch weapons would fail and switch back to the previous weapon.
The bug occurred due to a race condition with animations, where weapon switch inputs would still be processed while the weapon switch animation was playing.